### PR TITLE
added management.contextPath prop

### DIFF
--- a/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/AdminApplication.java
+++ b/spring-cloud-data-rest/src/main/java/org/springframework/cloud/data/rest/AdminApplication.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Import;
 public class AdminApplication {
 
 	public static void main(String[] args) throws InterruptedException {
-		SpringApplication.run(AdminApplication.class, "--server.port=9393");
+		SpringApplication.run(AdminApplication.class, "--server.port=9393", "--management.contextPath=/management");
 	}
 
 }


### PR DESCRIPTION
Not sure if this is what you were trying to accomplish, but by avoiding a conflict the boot management contextPath, the following is the result of `curl http://localhost:9393`:

```
{"_links":{"streams":{"href":"http://localhost:9393/streams"},"management":{"href":"http://localhost:9393/management"}}}
```
